### PR TITLE
Fix compilation error in base >= 4.8.0

### DIFF
--- a/src/Language/Lojban/Parser/ZasniGerna.hs
+++ b/src/Language/Lojban/Parser/ZasniGerna.hs
@@ -20,4 +20,5 @@ module Language.Lojban.Parser.ZasniGerna (
 	BU(..)
  ) where
 
+import Prelude hiding (Word)
 import Language.Lojban.Parser.ZasniGerna.Parser

--- a/src/Language/Lojban/Parser/ZasniGerna/Parser.hs
+++ b/src/Language/Lojban/Parser/ZasniGerna/Parser.hs
@@ -2,6 +2,7 @@
 
 module Language.Lojban.Parser.ZasniGerna.Parser where
 
+import Prelude hiding (Word)
 import Text.Papillon
 import Data.Maybe
 


### PR DESCRIPTION
From the [changelog](https://github.com/ghc/ghc/blob/master/libraries/base/changelog.md#4800--mar-2015) (version 4.8.0.0 Mar 2015):
* Re-export Data.Word.Word from Prelude